### PR TITLE
Fix monolithic setup

### DIFF
--- a/logstash.conf
+++ b/logstash.conf
@@ -122,9 +122,9 @@ filter {
             mutate { replace => { upstream => "blizzard" } }
 
 	    if [url_path] =~ "^\/tpr" {
-		grok {
-		    match => { "url_path" => "/tpr/%{DATA:blizzard_game}/%{WORD:blizzard_cdn_type}/%{GREEDYDATA:blizzard_data}" }
-		}
+		    grok {
+		        match => { "url_path" => "/tpr/%{DATA:blizzard_game}/%{WORD:blizzard_cdn_type}/%{GREEDYDATA:blizzard_data}" }
+		    }
 	    }
  
         # RIOT
@@ -135,7 +135,7 @@ filter {
         } else if [source] =~ "microsoft" or [cache_tag] == "microsoft" {
             mutate { replace => { upstream => "microsoft" } }
 
-	# WSUS
+        # WSUS
         } else if [source] =~ "wsus" or [cache_tag] == "wsus" {
             mutate { replace => { upstream => "wsus" } }
 
@@ -170,6 +170,7 @@ filter {
 					}
 				}
 			}
+
         # EPIC
         } else if [source] =~ "epicgames" or [cache_tag] == "epicgames" {
             mutate { replace => { upstream => "epicgames" } }

--- a/logstash.conf
+++ b/logstash.conf
@@ -81,13 +81,6 @@ filter {
         } else {
             mutate { add_tag => "lancache-unknown" }
         }
-		
-		# read the log line tag from mono cache
-		grok {
-			match => {
-				"message" => "\[%{HOSTNAME:cache_tag}\]"
-			}
-		}
 
         # STEAM
         if [source] =~ "steam" or [cache_tag] == "steam" {


### PR DESCRIPTION
In commit https://github.com/lancachenet/logstash/commit/194fda88fc92b9c3967bd8e837a55a73d17ddeee when the `cache_tag` was added in to the main grok match this had a regression causing issues for all dashboards as the `cache_tag` was being specified twice.

Instead of the `cache_tag` returning `steam` for example it would end up as `steam, steam` causing the upstream to be specified as `unknown` for everything.

This broke all of the dashboards as they are dependent on an explicit `upstream`.