### PR TITLE
Update ELK_VERSION to 7.17.29

### DIFF
--- a/docker-compose/.env
+++ b/docker-compose/.env
@@ -18,4 +18,4 @@ CACHE_ROOT=/etc/docker/containers/lancache/data
 # Other envs, these are less likely to need changing
 CACHE_LOGS=$CACHE_ROOT/logs
 # Set this at your own peril, this is set to the version that this repo has been tested on
-ELK_VERSION=7.17.9
+ELK_VERSION=7.17.29


### PR DESCRIPTION
Bump used ELK_VERSION to 7.17.29.
This version is confirmed to be working (checked all the dashboards)